### PR TITLE
Change base image to eclipse-temurin:17-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk
 
 COPY target/demo-app.jar  /usr/app/
 


### PR DESCRIPTION
bug fix: Change base image to eclipse-temurin:17-jdk